### PR TITLE
Security fix for ReDoS

### DIFF
--- a/src/isEmail.js
+++ b/src/isEmail.js
@@ -2,9 +2,10 @@ import compose from './compose';
 import isString from './isString';
 import matchesPattern from './matchesPattern';
 
+// https://www.regular-expressions.info/email.html
 const isEmail = compose(
   isString,
-  matchesPattern(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/),
+  matchesPattern(/^[a-z0-9!#$%&'*+/=?^_‘{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_‘{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
 );
 
 export default isEmail;


### PR DESCRIPTION
The `isEmail` functionality using vulnerable regex to verify email. Fixing the issue by Switch email pattern to the practical implementation of RFC 5322.

Reported in https://www.huntr.dev/bounties/2f42873d-83d7-4006-aa0e-65d085c01071/